### PR TITLE
fix: replace equality test with falsey test

### DIFF
--- a/enforce_git_message/git-templates/hooks/commit-msg
+++ b/enforce_git_message/git-templates/hooks/commit-msg
@@ -16,7 +16,7 @@ def main():
 	filename = sys.argv[1]
 	ss = open(filename, 'r').read()
 	m = re.match(pattern, ss)
-	if m == None: raise Exception("conventional commit validation failed")
+	if not m: raise Exception("conventional commit validation failed")
 
 if __name__ == "__main__":
 	main()

--- a/enforce_git_message/main.py
+++ b/enforce_git_message/main.py
@@ -2,7 +2,7 @@ import shutil, os
 
 def main():
 	template_path = os.path.expanduser("~/.git-templates/hooks/commit-msg")
-	if shutil.which('git') == None:
+	if not shutil.which('git'):
 		print('error: git not found on path. please install git and then run pip install --upgrade enforce-git-message')
 		return
 	if not os.path.exists(template_path):


### PR DESCRIPTION
The equality tests against a singleton like `None` should be avoided, and the identity test with `is` should be used instead as the equality tests can be overloaded using `__eq__`, but there is no overloading operator present for `is` (which refers to the memory location of the object).

Moreover, in here, we are testing only against `None` as other falsey values like empty strings cannot be present given the context. So, we can just do the *falsey* test i.e. `not <something>`.
